### PR TITLE
Langchainjs alignment

### DIFF
--- a/docs/core_docs/docs/integrations/vectorstores/hanavector.mdx
+++ b/docs/core_docs/docs/integrations/vectorstores/hanavector.mdx
@@ -89,6 +89,8 @@ SAP HANA Cloud Vector Engine supports computing embeddings directly in the datab
 
 To enable this functionality, instantiate a `HanaInternalEmbeddings` object with the internal embedding model ID and pass this instance to your `HanaDB` vector store.
 
+For more details on the `VECTOR_EMBEDDING` function, refer to the official [SAP HANA Cloud documentation](https://help.sap.com/docs/hana-cloud-database/sap-hana-cloud-sap-hana-database-vector-engine-guide/vector-embedding-function-vector?locale=en-US).
+
 import ExampleInternalEmbeddings from "@examples/indexes/vector_stores/hana_vector/internalEmbeddings.ts";
 
 <CodeBlock language="typescript">{ExampleInternalEmbeddings}</CodeBlock>

--- a/docs/core_docs/docs/integrations/vectorstores/hanavector.mdx
+++ b/docs/core_docs/docs/integrations/vectorstores/hanavector.mdx
@@ -61,8 +61,8 @@ In addition to the basic value-based filtering capabilities, it is possible to u
 | ----------- | -------------------------------------------------------------------------- |
 | `$eq`       | Equality (==)                                                              |
 | `$ne`       | Inequality (!=)                                                            |
-| `$lt`       | Less than (<)                                                              |
-| `$lte`      | Less than or equal (<=)                                                    |
+| `$lt`       | Less than (&lt;)                                                              |
+| `$lte`      | Less than or equal (&lt;=)                                                    |
 | `$gt`       | Greater than (>)                                                           |
 | `$gte`      | Greater than or equal (>=)                                                 |
 | `$in`       | Contained in a set of given values (in)                                    |

--- a/docs/core_docs/docs/integrations/vectorstores/hanavector.mdx
+++ b/docs/core_docs/docs/integrations/vectorstores/hanavector.mdx
@@ -82,6 +82,16 @@ import ExampleChain from "@examples/indexes/vector_stores/hana_vector/chains.ts"
 
 <CodeBlock language="typescript">{ExampleChain}</CodeBlock>
 
+## Internal Embedding Functionality
+
+SAP HANA Cloud Vector Engine supports computing embeddings directly in the database by leveraging its native `VECTOR_EMBEDDING` function. This approach eliminates the need for an external embedding service, improving performance and enhancing data security.
+
+To enable this functionality, instantiate a `HanaInternalEmbeddings` object with the internal embedding model ID and pass this instance to your `HanaDB` vector store.
+
+import ExampleInternalEmbeddings from "@examples/indexes/vector_stores/hana_vector/internalEmbeddings.ts";
+
+<CodeBlock language="typescript">{ExampleInternalEmbeddings}</CodeBlock>
+
 ## Related
 
 - Vector store [conceptual guide](/docs/concepts/#vectorstores)

--- a/docs/core_docs/docs/integrations/vectorstores/hanavector.mdx
+++ b/docs/core_docs/docs/integrations/vectorstores/hanavector.mdx
@@ -57,20 +57,21 @@ import { Table, Tr, Th, Td } from "@mdx-js/react";
 
 In addition to the basic value-based filtering capabilities, it is possible to use more advanced filtering. The table below shows the available filter operators.
 
-| Operator   | Semantic                                                                   |
-| ---------- | -------------------------------------------------------------------------- |
-| `$eq`      | Equality (==)                                                              |
-| `$ne`      | Inequality (!=)                                                            |
-| `$lt`      | Less than (<)                                                              |
-| `$lte`     | Less than or equal (<=)                                                    |
-| `$gt`      | Greater than (>)                                                           |
-| `$gte`     | Greater than or equal (>=)                                                 |
-| `$in`      | Contained in a set of given values (in)                                    |
-| `$nin`     | Not contained in a set of given values (not in)                            |
-| `$between` | Between the range of two boundary values                                   |
-| `$like`    | Text equality based on the "LIKE" semantics in SQL (using "%" as wildcard) |
-| `$and`     | Logical "and", supporting 2 or more operands                               |
-| `$or`      | Logical "or", supporting 2 or more operands                                |
+| Operator    | Semantic                                                                   |
+| ----------- | -------------------------------------------------------------------------- |
+| `$eq`       | Equality (==)                                                              |
+| `$ne`       | Inequality (!=)                                                            |
+| `$lt`       | Less than (<)                                                              |
+| `$lte`      | Less than or equal (<=)                                                    |
+| `$gt`       | Greater than (>)                                                           |
+| `$gte`      | Greater than or equal (>=)                                                 |
+| `$in`       | Contained in a set of given values (in)                                    |
+| `$nin`      | Not contained in a set of given values (not in)                            |
+| `$between`  | Between the range of two boundary values                                   |
+| `$like`     | Text equality based on the "LIKE" semantics in SQL (using "%" as wildcard) |
+| `$contains` | Filters documents containing a specific keyword                            |
+| `$and`      | Logical "and", supporting 2 or more operands                               |
+| `$or`       | Logical "or", supporting 2 or more operands                                |
 
 import ExampleAdvancedFilter from "@examples/indexes/vector_stores/hana_vector/advancedFiltering.ts";
 

--- a/examples/src/indexes/vector_stores/hana_vector/advancedFiltering.ts
+++ b/examples/src/indexes/vector_stores/hana_vector/advancedFiltering.ts
@@ -29,15 +29,15 @@ await new Promise<void>((resolve, reject) => {
 const docs: Document[] = [
   {
     pageContent: "First",
-    metadata: { name: "adam", is_active: true, id: 1, height: 10.0 },
+    metadata: { name: "Adam Smith", is_active: true, id: 1, height: 10.0 },
   },
   {
     pageContent: "Second",
-    metadata: { name: "bob", is_active: false, id: 2, height: 5.7 },
+    metadata: { name: "Bob Johnson", is_active: false, id: 2, height: 5.7 },
   },
   {
     pageContent: "Third",
-    metadata: { name: "jane", is_active: true, id: 3, height: 2.4 },
+    metadata: { name: "Jane Doe", is_active: true, id: 3, height: 2.4 },
   },
 ];
 
@@ -75,8 +75,8 @@ printFilterResult(
   await vectorStore.similaritySearch("just testing", 5, advancedFilter)
 );
 /* Filter: {"id":{"$ne":1}}
-{ name: 'bob', is_active: false, id: 2, height: 5.7 } 
-{ name: 'jane', is_active: true, id: 3, height: 2.4 }
+{ name: 'Bob Johnson', is_active: false, id: 2, height: 5.7 } 
+{ name: 'Jane Doe', is_active: true, id: 3, height: 2.4 }
 */
 
 // Between range
@@ -86,27 +86,27 @@ printFilterResult(
   await vectorStore.similaritySearch("just testing", 5, advancedFilter)
 );
 /* Filter: {"id":{"$between":[1,2]}}
-{ name: 'adam', is_active: true, id: 1, height: 10 }
-{ name: 'bob', is_active: false, id: 2, height: 5.7 } */
+{ name: 'Adam Smith', is_active: true, id: 1, height: 10 }
+{ name: 'Bob Johnson', is_active: false, id: 2, height: 5.7 } */
 
 // In list
-advancedFilter = { name: { $in: ["adam", "bob"] } };
+advancedFilter = { name: { $in: ["Adam Smith", "Bob Johnson"] } };
 console.log(`Filter: ${JSON.stringify(advancedFilter)}`);
 printFilterResult(
   await vectorStore.similaritySearch("just testing", 5, advancedFilter)
 );
-/* Filter: {"name":{"$in":["adam","bob"]}}
-{ name: 'adam', is_active: true, id: 1, height: 10 }
-{ name: 'bob', is_active: false, id: 2, height: 5.7 } */
+/* Filter: {"name":{"$in":["Adam Smith","Bob Johnson"]}}
+{ name: 'Adam Smith', is_active: true, id: 1, height: 10 }
+{ name: 'Bob Johnson', is_active: false, id: 2, height: 5.7 } */
 
 // Not in list
-advancedFilter = { name: { $nin: ["adam", "bob"] } };
+advancedFilter = { name: { $nin: ["Adam Smith", "Bob Johnson"] } };
 console.log(`Filter: ${JSON.stringify(advancedFilter)}`);
 printFilterResult(
   await vectorStore.similaritySearch("just testing", 5, advancedFilter)
 );
-/* Filter: {"name":{"$nin":["adam","bob"]}}
-{ name: 'jane', is_active: true, id: 3, height: 2.4 } */
+/* Filter: {"name":{"$nin":["Adam Smith","Bob Johnson"]}}
+{ name: 'Jane Doe', is_active: true, id: 3, height: 2.4 } */
 
 // Greater than
 advancedFilter = { id: { $gt: 1 } };
@@ -115,8 +115,8 @@ printFilterResult(
   await vectorStore.similaritySearch("just testing", 5, advancedFilter)
 );
 /* Filter: {"id":{"$gt":1}}
-{ name: 'bob', is_active: false, id: 2, height: 5.7 }
-{ name: 'jane', is_active: true, id: 3, height: 2.4 } */
+{ name: 'Bob Johnson', is_active: false, id: 2, height: 5.7 }
+{ name: 'Jane Doe', is_active: true, id: 3, height: 2.4 } */
 
 // Greater than or equal to
 advancedFilter = { id: { $gte: 1 } };
@@ -125,9 +125,9 @@ printFilterResult(
   await vectorStore.similaritySearch("just testing", 5, advancedFilter)
 );
 /* Filter: {"id":{"$gte":1}}
-{ name: 'adam', is_active: true, id: 1, height: 10 }
-{ name: 'bob', is_active: false, id: 2, height: 5.7 }
-{ name: 'jane', is_active: true, id: 3, height: 2.4 } */
+{ name: 'Adam Smith', is_active: true, id: 1, height: 10 }
+{ name: 'Bob Johnson', is_active: false, id: 2, height: 5.7 }
+{ name: 'Jane Doe', is_active: true, id: 3, height: 2.4 } */
 
 // Less than
 advancedFilter = { id: { $lt: 1 } };
@@ -145,7 +145,7 @@ printFilterResult(
   await vectorStore.similaritySearch("just testing", 5, advancedFilter)
 );
 /* Filter: {"id":{"$lte":1}}
-{ name: 'adam', is_active: true, id: 1, height: 10 } */
+{ name: 'Adam Smith', is_active: true, id: 1, height: 10 } */
 
 // Text filtering with $like
 advancedFilter = { name: { $like: "a%" } };
@@ -154,7 +154,7 @@ printFilterResult(
   await vectorStore.similaritySearch("just testing", 5, advancedFilter)
 );
 /* Filter: {"name":{"$like":"a%"}}
-{ name: 'adam', is_active: true, id: 1, height: 10 } */
+{ name: 'Adam Smith', is_active: true, id: 1, height: 10 } */
 
 advancedFilter = { name: { $like: "%a%" } };
 console.log(`Filter: ${JSON.stringify(advancedFilter)}`);
@@ -162,18 +162,35 @@ printFilterResult(
   await vectorStore.similaritySearch("just testing", 5, advancedFilter)
 );
 /* Filter: {"name":{"$like":"%a%"}}
-{ name: 'adam', is_active: true, id: 1, height: 10 }
-{ name: 'jane', is_active: true, id: 3, height: 2.4 } */
+{ name: 'Adam Smith', is_active: true, id: 1, height: 10 }
+{ name: 'Jane Doe', is_active: true, id: 3, height: 2.4 } */
 
-// Combined filtering with $or
-advancedFilter = { $or: [{ id: 1 }, { name: "bob" }] };
+// Text filtering with $contains
+advancedFilter = { name: { $contains: "bob" } };
 console.log(`Filter: ${JSON.stringify(advancedFilter)}`);
 printFilterResult(
   await vectorStore.similaritySearch("just testing", 5, advancedFilter)
 );
-/* Filter: {"$or":[{"id":1},{"name":"bob"}]}
-{ name: 'adam', is_active: true, id: 1, height: 10 }
-{ name: 'bob', is_active: false, id: 2, height: 5.7 } */
+/* Filter: {"name":{"$contains":"bob"}}
+{ name: 'Bob Johnson', is_active: false, id: 2, height: 5.7 } */
+
+advancedFilter = { name: { $contains: "bo" } };
+console.log(`Filter: ${JSON.stringify(advancedFilter)}`);
+printFilterResult(
+  await vectorStore.similaritySearch("just testing", 5, advancedFilter)
+);
+/* Filter: {"name":{"$contains":"bo"}}
+<empty result> */
+
+// Combined filtering with $or
+advancedFilter = { $or: [{ id: 1 }, { name: "Bob Johnson" }] };
+console.log(`Filter: ${JSON.stringify(advancedFilter)}`);
+printFilterResult(
+  await vectorStore.similaritySearch("just testing", 5, advancedFilter)
+);
+/* Filter: {"$or":[{"id":1},{"name":"Bob Johnson"}]}
+{ name: 'Adam Smith', is_active: true, id: 1, height: 10 }
+{ name: 'Bob Johnson', is_active: false, id: 2, height: 5.7 } */
 
 // Combined filtering with $and
 advancedFilter = { $and: [{ id: 1 }, { id: 2 }] };
@@ -184,15 +201,23 @@ printFilterResult(
 /* Filter: {"$and":[{"id":1},{"id":2}]}
 <empty result> */
 
+advancedFilter = { $and: [{ name: { $contains: "bob" } }, { id: 2 }] };
+console.log(`Filter: ${JSON.stringify(advancedFilter)}`);
+printFilterResult(
+  await vectorStore.similaritySearch("just testing", 5, advancedFilter)
+);
+/* Filter: {"$and":[{"name":{"$contains":"bob"}},{"id":2}]}
+{ name: 'Bob Johnson', is_active: false, id: 2, height: 5.7 } */
+
 advancedFilter = { $or: [{ id: 1 }, { id: 2 }, { id: 3 }] };
 console.log(`Filter: ${JSON.stringify(advancedFilter)}`);
 printFilterResult(
   await vectorStore.similaritySearch("just testing", 5, advancedFilter)
 );
 /* Filter: {"$or":[{"id":1},{"id":2},{"id":3}]}
-{ name: 'adam', is_active: true, id: 1, height: 10 }
-{ name: 'bob', is_active: false, id: 2, height: 5.7 }
-{ name: 'jane', is_active: true, id: 3, height: 2.4 } */
+{ name: 'Adam Smith', is_active: true, id: 1, height: 10 }
+{ name: 'Bob Johnson', is_active: false, id: 2, height: 5.7 }
+{ name: 'Jane Doe', is_active: true, id: 3, height: 2.4 } */
 
 // You can also define a nested filter with $and and $or.
 advancedFilter = {
@@ -203,8 +228,8 @@ printFilterResult(
   await vectorStore.similaritySearch("just testing", 5, advancedFilter)
 );
 /* Filter: {"$and":[{"$or":[{"id":1},{"id":2}]},{"height":{"$gte":5.0}}]}
-{ name: 'adam', is_active: true, id: 1, height: 10 } 
-{ name: 'bob', is_active: false, id: 2, height: 5.7 } */
+{ name: 'Adam Smith', is_active: true, id: 1, height: 10 } 
+{ name: 'Bob Johnson', is_active: false, id: 2, height: 5.7 } */
 
 // Disconnect from SAP HANA aft er the operations
 client.disconnect();

--- a/examples/src/indexes/vector_stores/hana_vector/internalEmbeddings.ts
+++ b/examples/src/indexes/vector_stores/hana_vector/internalEmbeddings.ts
@@ -1,0 +1,81 @@
+import { Document } from "@langchain/core/documents";
+import hanaClient from "hdb";
+import { HanaInternalEmbeddings } from "@langchain/community/embeddings/hana_internal";
+import { HanaDB, HanaDBArgs } from "@langchain/community/vectorstores/hanavector";
+
+// Initialize the internal embeddings instance using the internal model ID.
+// This instance will use SAP HANA's built-in VECTOR_EMBEDDING function of HanaDB.
+const internalEmbeddings = new HanaInternalEmbeddings({
+  internalEmbeddingModelId: process.env.HANA_DB_EMBEDDING_MODEL_ID || "your_model_id",
+});
+
+// Set up connection parameters from environment variables.
+const connectionParams = {
+  host: process.env.HANA_HOST,
+  port: process.env.HANA_PORT,
+  user: process.env.HANA_UID,
+  password: process.env.HANA_PWD,
+};
+
+// Create a HANA client.
+const client = hanaClient.createClient(connectionParams);
+
+// Connect to SAP HANA.
+await new Promise<void>((resolve, reject) => {
+  client.connect((err: Error) => {
+    if (err) {
+      reject(err);
+    } else {
+      console.log("Connected to SAP HANA successfully.");
+      resolve();
+    }
+  });
+});
+
+// Define the arguments for the vector store instance.
+const args: HanaDBArgs = {
+  connection: client,
+  tableName: "testInternalEmbeddings",
+};
+
+// Create a new HanaDB vector store using the internal embeddings instance.
+// This vector store leverages the internal VECTOR_EMBEDDING function of HanaDB.
+const vectorStore = new HanaDB(internalEmbeddings, args);
+// Initialize the vector store (creates the table and verifies its columns).
+await vectorStore.initialize();
+
+// Example documents to index.
+const docs: Document[] = [
+  new Document({
+    pageContent: "Charlie is a data scientist who specializes in AI research.",
+    metadata: { name: "Charlie Brown" },
+  }),
+  new Document({
+    pageContent: "David is a teacher with a passion for history and literature.",
+    metadata: { name: "David Williams" },
+  }),
+  new Document({
+    pageContent: "Eve is an entrepreneur focusing on blockchain and cryptocurrency.",
+    metadata: { name: "Eve Adams" },
+  }),
+];
+
+// Clean up any existing documents in the table.
+await vectorStore.delete({ filter: {} });
+// Add the example documents.
+await vectorStore.addDocuments(docs);
+
+// Perform a similarity search. In this example, we search for documents related to "bitcoin".
+const results = await vectorStore.similaritySearch("bitcoin", 1);
+console.log("Similarity search results:", results);
+/*
+  [
+    {
+      pageContent: 'Eve is an entrepreneur focusing on blockchain and cryptocurrency.',
+      metadata: { name: 'Eve Adams' }
+    }
+  ]
+*/
+
+// Disconnect from SAP HANA after operations.
+client.disconnect();

--- a/examples/src/indexes/vector_stores/hana_vector/internalEmbeddings.ts
+++ b/examples/src/indexes/vector_stores/hana_vector/internalEmbeddings.ts
@@ -6,7 +6,7 @@ import { HanaDB, HanaDBArgs } from "@langchain/community/vectorstores/hanavector
 // Initialize the internal embeddings instance using the internal model ID.
 // This instance will use SAP HANA's built-in VECTOR_EMBEDDING function of HanaDB.
 const internalEmbeddings = new HanaInternalEmbeddings({
-  internalEmbeddingModelId: process.env.HANA_DB_EMBEDDING_MODEL_ID || "your_model_id",
+  internalEmbeddingModelId: process.env.HANA_DB_EMBEDDING_MODEL_ID || "SAP_NEB.20240715",
 });
 
 // Set up connection parameters from environment variables.

--- a/libs/langchain-community/.gitignore
+++ b/libs/langchain-community/.gitignore
@@ -170,6 +170,10 @@ embeddings/gradient_ai.cjs
 embeddings/gradient_ai.js
 embeddings/gradient_ai.d.ts
 embeddings/gradient_ai.d.cts
+embeddings/hana_internal.cjs
+embeddings/hana_internal.js
+embeddings/hana_internal.d.ts
+embeddings/hana_internal.d.cts
 embeddings/hf.cjs
 embeddings/hf.js
 embeddings/hf.d.ts

--- a/libs/langchain-community/langchain.config.js
+++ b/libs/langchain-community/langchain.config.js
@@ -78,6 +78,7 @@ export const config = {
     "embeddings/deepinfra": "embeddings/deepinfra",
     "embeddings/fireworks": "embeddings/fireworks",
     "embeddings/gradient_ai": "embeddings/gradient_ai",
+    "embeddings/hana_internal": "embeddings/hana_internal",
     "embeddings/hf": "embeddings/hf",
     "embeddings/hf_transformers": "embeddings/hf_transformers",
     "embeddings/huggingface_transformers": "embeddings/huggingface_transformers",

--- a/libs/langchain-community/package.json
+++ b/libs/langchain-community/package.json
@@ -1105,6 +1105,15 @@
       "import": "./embeddings/gradient_ai.js",
       "require": "./embeddings/gradient_ai.cjs"
     },
+    "./embeddings/hana_internal": {
+      "types": {
+        "import": "./embeddings/hana_internal.d.ts",
+        "require": "./embeddings/hana_internal.d.cts",
+        "default": "./embeddings/hana_internal.d.ts"
+      },
+      "import": "./embeddings/hana_internal.js",
+      "require": "./embeddings/hana_internal.cjs"
+    },
     "./embeddings/hf": {
       "types": {
         "import": "./embeddings/hf.d.ts",
@@ -3378,6 +3387,10 @@
     "embeddings/gradient_ai.js",
     "embeddings/gradient_ai.d.ts",
     "embeddings/gradient_ai.d.cts",
+    "embeddings/hana_internal.cjs",
+    "embeddings/hana_internal.js",
+    "embeddings/hana_internal.d.ts",
+    "embeddings/hana_internal.d.cts",
     "embeddings/hf.cjs",
     "embeddings/hf.js",
     "embeddings/hf.d.ts",

--- a/libs/langchain-community/src/embeddings/hana_internal.ts
+++ b/libs/langchain-community/src/embeddings/hana_internal.ts
@@ -34,6 +34,7 @@ export class HanaInternalEmbeddings extends Embeddings {
    * A flag to indicate this class is HANA-specific.
    */
   public readonly isHanaInternalEmbeddings = true;
+  
   constructor(fields: HanaInternalEmbeddingsParams) {
     super(fields);
     this.modelId = fields.internalEmbeddingModelId;

--- a/libs/langchain-community/src/embeddings/hana_internal.ts
+++ b/libs/langchain-community/src/embeddings/hana_internal.ts
@@ -1,0 +1,69 @@
+import { Embeddings, type EmbeddingsParams } from "@langchain/core/embeddings";
+
+/**
+ * Parameters for initializing HanaInternalEmbeddings.
+ */
+export interface HanaInternalEmbeddingsParams extends EmbeddingsParams {
+  /**
+   * The ID of the internal embedding model used by the HANA database.
+   */
+  internalEmbeddingModelId: string;
+}
+
+/**
+ * A dummy embeddings class for use with HANA's internal embedding functionality.
+ * This class prevents the use of standard embedding methods and ensures that
+ * internal embeddings are handled exclusively via database queries.
+ *
+ * @example
+ *  const internalEmbeddings = new HanaInternalEmbeddings({
+ *    internalEmbeddingModelId: "your_model_id_here",
+ *  });
+ *
+ *  // The following calls will throw errors:
+ *  await internalEmbeddings.embedQuery("sample text"); // Throws error
+ *  await internalEmbeddings.embedDocuments(["text one", "text two"]); // Throws error
+ *
+ *  // Retrieve the internal model id:
+ *  console.log(internalEmbeddings.getModelId());
+ */
+export class HanaInternalEmbeddings extends Embeddings {
+  private modelId: string;
+
+  /**
+   * A flag to indicate this class is HANA-specific.
+   */
+  public readonly isHanaInternalEmbeddings = true;
+  constructor(fields: HanaInternalEmbeddingsParams) {
+    super(fields);
+    this.modelId = fields.internalEmbeddingModelId;
+  }
+
+  /**
+   * This method is not applicable for HANA internal embeddings.
+   * @throws Error indicating that internal embeddings cannot be used externally.
+   */
+  async embedQuery(_text: string): Promise<number[]> {
+    throw new Error(
+      "Internal embeddings cannot be used externally. Use HANA's internal embedding functionality instead."
+    );
+  }
+
+  /**
+   * This method is not applicable for HANA internal embeddings.
+   * @throws Error indicating that internal embeddings cannot be used externally.
+   */
+  async embedDocuments(_texts: string[]): Promise<number[][]> {
+    throw new Error(
+      "Internal embeddings cannot be used externally. Use HANA's internal embedding functionality instead."
+    );
+  }
+
+  /**
+   * Retrieves the internal embedding model ID.
+   * @returns The internal embedding model ID.
+   */
+  getModelId(): string {
+    return this.modelId;
+  }
+}

--- a/libs/langchain-community/src/load/import_map.ts
+++ b/libs/langchain-community/src/load/import_map.ts
@@ -30,6 +30,7 @@ export * as embeddings__baidu_qianfan from "../embeddings/baidu_qianfan.js";
 export * as embeddings__bytedance_doubao from "../embeddings/bytedance_doubao.js";
 export * as embeddings__deepinfra from "../embeddings/deepinfra.js";
 export * as embeddings__fireworks from "../embeddings/fireworks.js";
+export * as embeddings__hana_internal from "../embeddings/hana_internal.js";
 export * as embeddings__minimax from "../embeddings/minimax.js";
 export * as embeddings__ollama from "../embeddings/ollama.js";
 export * as embeddings__togetherai from "../embeddings/togetherai.js";

--- a/libs/langchain-community/src/vectorstores/hanavector.ts
+++ b/libs/langchain-community/src/vectorstores/hanavector.ts
@@ -672,7 +672,7 @@ export class HanaDB extends VectorStore {
   ): string {
     const metadataColumns = projectedMetadataColumns.map(
       (col) =>
-        `JSON_VALUE(${this.metadataColumn}, '$.${col}') AS "${col}"`
+        `JSON_VALUE(${this.metadataColumn}, '$.${HanaDB.sanitizeName(col)}') AS "${HanaDB.sanitizeName(col)}"`
     );
     return (
       `WITH ${INTERMEDIATE_TABLE_NAME} AS (` +

--- a/libs/langchain-community/src/vectorstores/hanavector.ts
+++ b/libs/langchain-community/src/vectorstores/hanavector.ts
@@ -6,6 +6,8 @@ import {
 import { Document } from "@langchain/core/documents";
 import { maximalMarginalRelevance } from "@langchain/core/utils/math";
 
+import { HanaInternalEmbeddings } from "../embeddings/hana_internal.js";
+
 export type DistanceStrategy = "euclidean" | "cosine";
 
 const COMPARISONS_TO_SQL: Record<string, string> = {
@@ -132,6 +134,10 @@ export class HanaDB extends VectorStore {
 
   private specificMetadataColumns: string[];
 
+  private useInternalEmbeddings: boolean;
+
+  private internalEmbeddingModelId: string;
+
   _vectorstoreType(): string {
     return "hanadb";
   }
@@ -157,6 +163,51 @@ export class HanaDB extends VectorStore {
       args.specificMetadataColumns || []
     );
     this.connection = args.connection;
+
+    // Set the embedding and decide whether to use internal embedding
+    this.setEmbeddings(embeddings);
+  }
+
+  /**
+   * Use this method yto chanbe the embeddings instance
+   * 
+   * Sets the embedding instance and configures the internal embedding mode 
+   * if applicable.
+   *
+   * this method sets the internal flag and stores the model ID. 
+   * Otherwise, it ensures that external embedding mode is used.
+   *
+   * @param embeddings - An instance of EmbeddingsInterface.
+   */
+  public setEmbeddings(embeddings: EmbeddingsInterface): void {
+    this.embeddings = embeddings
+    if ((embeddings as any).isHanaInternalEmbeddings === true) {
+      this.useInternalEmbeddings = true;
+      this.internalEmbeddingModelId = (embeddings as HanaInternalEmbeddings).getModelId();
+    } else {
+      this.useInternalEmbeddings = false;
+      this.internalEmbeddingModelId = "";
+    }
+  }
+
+  /**
+   * Ping the database to check if the in-database embedding 
+   * function exists and works.
+   * 
+   * This method ensures that the internal VECTOR_EMBEDDING function 
+   * is available and functioning correctly by passing a test value. 
+   *
+   * @throws Error if the internal embedding function validation fails.
+   */
+  private async validateInternalEmbeddingFunction(): Promise<void> {
+    if (!this.internalEmbeddingModelId) {
+      throw new Error("Internal embedding model id is not set");
+    }
+    const sqlStr =
+      "SELECT TO_NVARCHAR(VECTOR_EMBEDDING('test', 'QUERY', ?)) AS TEST FROM sys.DUMMY;";
+    const client = this.connection;
+    const stm = await this.prepareQuery(client, sqlStr);
+    await this.executeStatement(stm, [this.internalEmbeddingModelId]);
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -202,6 +253,8 @@ export class HanaDB extends VectorStore {
   }
 
   public async initialize() {
+    if (this.useInternalEmbeddings)
+      await this.validateInternalEmbeddingFunction();
     let valid_distance = false;
     for (const key in HANA_DISTANCE_FUNCTION) {
       if (key === this.distanceStrategy) {
@@ -808,18 +861,67 @@ export class HanaDB extends VectorStore {
   }
 
   /**
-   * Adds an array of documents to the table. The documents are first
-   * converted to vectors using the `embedDocuments` method of the
-   * `embeddings` instance.
+   * Adds an array of documents to the table. 
+   * 
+   * 
+   * In external embedding mode, this method computes embeddings client-side 
+   * and inserts them.
+   * In internal embedding mode, it leverages the database's internal 
+   * VECTOR_EMBEDDING function to generate embeddings.
+   * 
    * @param documents Array of Document instances to be added to the table.
    * @returns Promise that resolves when the documents are added.
    */
   async addDocuments(documents: Document[]): Promise<void> {
+    // If using internal embeddings, we do NOT call embedDocuments() from Node.
+    if (this.useInternalEmbeddings) {
+      return this.addDocumentsUsingInternalEmbedding(documents);
+    }
+    // Otherwise, default (external) approach:
     const texts = documents.map(({ pageContent }) => pageContent);
     return this.addVectors(
       await this.embeddings.embedDocuments(texts),
       documents
     );
+  }
+
+  /**
+   * Adds documents to the database using the internal embedding function.
+   *
+   * This method constructs an SQL INSERT statement that leverages the 
+   * database's internal VECTOR_EMBEDDING function to generate embeddings 
+   * on the server side.
+   *
+   * @param documents - Array of Document objects to be added.
+   * @returns Promise that resolves when the documents are added.
+   */
+  private async addDocumentsUsingInternalEmbedding(documents: Document[]): Promise<void> {
+    const texts = documents.map((doc) => doc.pageContent);
+    const metadatas = documents.map((doc) => doc.metadata);
+    const client = this.connection;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const sqlParams: [string, string, ...any[]][] = texts.map((text, i) => {
+      const metadata = Array.isArray(metadatas) ? metadatas[i] : metadatas;
+      const [remainingMetadata, specialMetadata] = this.splitOffSpecialMetadata(metadata);
+      // Prepare the SQL parameters
+      return [
+        text,
+        JSON.stringify(this.sanitizeMetadataKeys(remainingMetadata)),
+        text, 
+        this.internalEmbeddingModelId,
+        ...specialMetadata
+      ];
+    });
+    // Build the column list for the INSERT statement.
+    const specificMetadataColumnsString = this.getSpecificMetadataColumnsString()
+    const extraPlaceholders = this.specificMetadataColumns.map(() => ", ?").join("");
+
+    // Insert data into the table, bulk insert.
+    const sqlStr = `INSERT INTO "${this.tableName}" ("${this.contentColumn}", "${this.metadataColumn}", "${this.vectorColumn}"${specificMetadataColumnsString}) 
+                    VALUES (?, ?, VECTOR_EMBEDDING(?, 'DOCUMENT', ?)${extraPlaceholders});`;
+    const stm = await this.prepareQuery(client, sqlStr);
+    await this.executeStatement(stm, sqlParams);
+    // stm.execBatch(sqlParams);
   }
 
   /**
@@ -836,6 +938,7 @@ export class HanaDB extends VectorStore {
     const texts = documents.map((doc) => doc.pageContent);
     const metadatas = documents.map((doc) => doc.metadata);
     const client = this.connection;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const sqlParams: [string, string, string, ...any[]][] = texts.map((text, i) => {
       const metadata = Array.isArray(metadatas) ? metadatas[i] : metadatas;
       const [remainingMetadata, specialMetadata] = this.splitOffSpecialMetadata(metadata);
@@ -850,11 +953,7 @@ export class HanaDB extends VectorStore {
       ];
     });
     // Build the column list for the INSERT statement.
-    let specificMetadataColumnsString = "";
-    if (this.specificMetadataColumns.length > 0) {
-      specificMetadataColumnsString =
-        ', "' + this.specificMetadataColumns.join('", "') + '"';
-    }
+    const specificMetadataColumnsString = this.getSpecificMetadataColumnsString()
     const extraPlaceholders = this.specificMetadataColumns.map(() => ", ?").join("");
 
     // Insert data into the table, bulk insert.
@@ -866,6 +965,22 @@ export class HanaDB extends VectorStore {
   }
 
   /**
+   * Helper function to generate the SQL snippet for specific metadata columns.
+   *
+   * Returns a string in the format: ', "col1", "col2", ...' 
+   * if specific metadata columns are defined,
+   * or an empty string if there are none.
+   *
+   * @returns A string representing the specific metadata columns for SQL insertion.
+   */
+  private getSpecificMetadataColumnsString(): string{
+    if (this.specificMetadataColumns.length === 0) {
+      return "";
+    }
+    return ', "' + this.specificMetadataColumns.join('", "') + '"';
+  } 
+
+  /**
    * Splits the given metadata object into two parts:
    * 1. The original metadata (unchanged).
    * 2. An array of special metadata values corresponding to each column
@@ -875,6 +990,7 @@ export class HanaDB extends VectorStore {
    * @returns A tuple where the first element is the original metadata object,
    *          and the second element is an array of special metadata values.
    */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   private splitOffSpecialMetadata(metadata: any): [any, (string | null)[]] {
     const specialMetadata: (string | null)[] = [];
     if (!metadata) {
@@ -887,13 +1003,13 @@ export class HanaDB extends VectorStore {
   }
 
   /**
-     * Return docs most similar to query.
-     * @param query Query text for the similarity search.
-     * @param k Number of Documents to return. Defaults to 4.
-     * @param filter A dictionary of metadata fields and values to filter by.
-                    Defaults to None.
-     * @returns Promise that resolves to a list of documents and their corresponding similarity scores.
-     */
+   * Return docs most similar to query.
+   * @param query Query text for the similarity search.
+   * @param k Number of Documents to return. Defaults to 4.
+   * @param filter A dictionary of metadata fields and values to filter by.
+                  Defaults to None.
+    * @returns Promise that resolves to a list of documents and their corresponding similarity scores.
+    */
   async similaritySearch(
     query: string,
     k: number,
@@ -904,30 +1020,47 @@ export class HanaDB extends VectorStore {
   }
 
   /**
-     * Return documents and score values most similar to query.
-     * @param query Query text for the similarity search.
-     * @param k Number of Documents to return. Defaults to 4.
-     * @param filter A dictionary of metadata fields and values to filter by.
-                    Defaults to None.
-     * @returns Promise that resolves to a list of documents and their corresponding similarity scores.
-     */
+   * Return documents and score values most similar to query.
+   * @param query Query text for the similarity search.
+   * @param k Number of Documents to return. Defaults to 4.
+   * @param filter A dictionary of metadata fields and values to filter by.
+                  Defaults to None.
+    * @returns Promise that resolves to a list of documents and their corresponding similarity scores.
+    */
   async similaritySearchWithScore(
     query: string,
     k: number,
     filter?: this["FilterType"]
   ): Promise<[Document, number][]> {
-    const queryEmbedding = await this.embeddings.embedQuery(query);
-    return this.similaritySearchVectorWithScore(queryEmbedding, k, filter);
+    let wholeResult = null
+    if (this.useInternalEmbeddings) {
+      // Internal embeddings: pass the query directly
+      wholeResult = await this.similaritySearchWithScoreAndVectorByQuery(
+        query,
+        k,
+        filter
+      );
+    } else {
+      const queryEmbedding = await this.embeddings.embedQuery(query);
+      // External embeddings: generate embedding from the query
+      wholeResult = await this.similaritySearchWithScoreAndVectorByVector(
+        queryEmbedding,
+        k,
+        filter
+      );
+    }
+    return wholeResult.map(([doc, score]) => [doc, score]);
+
   }
 
   /**
-     * Return docs most similar to the given embedding.
-     * @param query Query embedding for the similarity search.
-     * @param k Number of Documents to return. Defaults to 4.
-     * @param filter A dictionary of metadata fields and values to filter by.
-                    Defaults to None.
-     * @returns Promise that resolves to a list of documents and their corresponding similarity scores.
-     */
+   * Return docs most similar to the given embedding.
+   * @param query Query embedding for the similarity search.
+   * @param k Number of Documents to return. Defaults to 4.
+   * @param filter A dictionary of metadata fields and values to filter by.
+                  Defaults to None.
+   * @returns Promise that resolves to a list of documents and their corresponding similarity scores.
+   */
   async similaritySearchVectorWithScore(
     queryEmbedding: number[],
     k: number,
@@ -943,24 +1076,28 @@ export class HanaDB extends VectorStore {
   }
 
   /**
-   * Performs a similarity search based on vector comparison and returns documents along with their similarity scores and vectors.
-   * @param embedding The vector representation of the query for similarity comparison.
-   * @param k The number of top similar documents to return.
-   * @param filter Optional filter criteria to apply to the search query.
-   * @returns A promise that resolves to an array of tuples, each containing a Document, its similarity score, and its vector.
+   * Performs a similarity search using the provided embedding expression.
+   *
+   * This helper method is used by both external and internal similarity search methods
+   * to construct and execute the SQL query.
+   *
+   * @param embeddingExpr - SQL expression that represents or generates the query embedding.
+   * @param k - The number of documents to return.
+   * @param filter A dictionary of metadata fields and values to filter by.
+                  Defaults to None.
+   * @param vectorEmbeddingParams - Optional parameters for the embedding expression (used in internal mode).
+   * @returns Promise that resolves to a list of documents and their corresponding similarity scores.
    */
-  async similaritySearchWithScoreAndVectorByVector(
-    embedding: number[],
+  private async similaritySearchWithScoreAndVector(
+    embeddingExpr: string,
     k: number,
-    filter?: this["FilterType"]
+    filter?: this["FilterType"],
+    vectorEmbeddingParams?: string[]
   ): Promise<Array<[Document, number, number[]]>> {
     // Sanitize inputs
     const sanitizedK = HanaDB.sanitizeInt(k);
-    const sanitizedEmbedding = HanaDB.sanitizeListFloat(embedding);
     // Determine the distance function based on the configured strategy
     const distanceFuncName = HANA_DISTANCE_FUNCTION[this.distanceStrategy][0];
-    // Convert the embedding vector to a string for SQL query
-    const embeddingAsString = sanitizedEmbedding.join(",");
 
     // Keyword search: extract metadata columns used with $contains
     const projectedMetadataColumns = this.extractKeywordSearchColumns(filter);
@@ -976,7 +1113,7 @@ export class HanaDB extends VectorStore {
                     "${this.contentColumn}", 
                     "${this.metadataColumn}", 
                     TO_NVARCHAR("${this.vectorColumn}") AS VECTOR, 
-                    ${distanceFuncName}("${this.vectorColumn}", TO_REAL_VECTOR('[${embeddingAsString}]')) AS CS
+                    ${distanceFuncName}("${this.vectorColumn}", ${embeddingExpr}) AS CS
                     FROM ${fromClause}`;
     // Add order by clause to sort by similarity
     const orderStr = ` ORDER BY CS ${
@@ -984,7 +1121,11 @@ export class HanaDB extends VectorStore {
     }`;
 
     // Prepare and execute the SQL query
-    const [whereStr, queryTuple] = this.createWhereByFilter(filter);
+    const [whereStr, tempQueryTuple] = this.createWhereByFilter(filter);
+    let queryTuple = tempQueryTuple
+    if (vectorEmbeddingParams && vectorEmbeddingParams.length > 0) {
+      queryTuple = [...vectorEmbeddingParams, ...queryTuple];
+    }
 
     sqlStr += whereStr + orderStr;
     const client = this.connection;
@@ -1008,9 +1149,65 @@ export class HanaDB extends VectorStore {
   }
 
   /**
+   * Performs a similarity search based on vector comparison and returns documents along with their similarity scores and vectors.
+   * @param embedding The vector representation of the query for similarity comparison.
+   * @param k The number of top similar documents to return.
+   * @param filter Optional filter criteria to apply to the search query.
+   * @returns A promise that resolves to an array of tuples, each containing a Document, its similarity score, and its vector.
+   */
+  async similaritySearchWithScoreAndVectorByVector(
+    embedding: number[],
+    k: number,
+    filter?: this["FilterType"]
+  ): Promise<Array<[Document, number, number[]]>> {
+    // Convert the embedding vector to a string for SQL query
+    const sanitizedEmbedding = HanaDB.sanitizeListFloat(embedding);
+    const embeddingAsString = sanitizedEmbedding.join(",");
+    return this.similaritySearchWithScoreAndVector(
+      `TO_REAL_VECTOR('[${embeddingAsString}]')`,
+      k, 
+      filter
+    );
+  }
+
+  /**
+   * Performs a similarity search using the internal embedding function.
+   *
+   * In this mode, the query text is passed directly to the database's internal VECTOR_EMBEDDING function.
+   *
+   * @param query - The query text.
+   * @param k - The number of documents to return.
+   * @param filter A dictionary of metadata fields and values to filter by.
+                  Defaults to None.
+   * @returns A promise that resolves to an array of tuples, each containing a Document, its similarity score, and its vector.
+   * @throws Error if internal embedding mode is not active.
+   */
+    async similaritySearchWithScoreAndVectorByQuery(
+      query: string,
+      k: number,
+      filter?: this["FilterType"]
+    ): Promise<Array<[Document, number, number[]]>> {
+      if (!this.useInternalEmbeddings) {
+        throw new Error(
+          "Internal embedding search requires an internal embedding instance."
+        );
+      }
+      const vectorEmbeddingParams = [query, this.internalEmbeddingModelId]
+      return this.similaritySearchWithScoreAndVector(
+        "VECTOR_EMBEDDING(?, 'QUERY', ?)",
+        k,
+        filter,
+        vectorEmbeddingParams
+      );
+    }
+
+  /**
    * Return documents selected using the maximal marginal relevance.
    * Maximal marginal relevance optimizes for similarity to the query AND
    * diversity among selected documents.
+   * When using an internal embedding instance, the query is processed 
+   * directly by the database's internal embedding function.
+   * Otherwise, the query is embedded externally.
    * @param query Text to look up documents similar to.
    * @param options.k Number of documents to return.
    * @param options.fetchK=20 Number of documents to fetch before passing to
@@ -1025,7 +1222,25 @@ export class HanaDB extends VectorStore {
     options: MaxMarginalRelevanceSearchOptions<this["FilterType"]>
   ): Promise<Document[]> {
     const { k, fetchK = 20, lambda = 0.5 } = options;
-    const queryEmbedding = await this.embeddings.embedQuery(query);
+    let queryEmbedding: number[];
+    if (this.useInternalEmbeddings){
+      const sqlStr = `SELECT TO_NVARCHAR(VECTOR_EMBEDDING(?, 'QUERY', ?))
+       AS VECTOR FROM sys.DUMMY;`
+      const queryTuple = [query, this.internalEmbeddingModelId]
+      const client = this.connection;
+      const stm = await this.prepareQuery(client, sqlStr);
+      const resultSet = await this.executeStatement(stm, queryTuple);
+      const result: [number[]] = resultSet.map(
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (row: any) => {
+          return HanaDB.parseFloatArrayFromString(row.VECTOR);
+        }
+      );
+      queryEmbedding = result[0]
+    }
+    else {
+      queryEmbedding = await this.embeddings.embedQuery(query);
+    }
 
     const docs = await this.similaritySearchWithScoreAndVectorByVector(
       queryEmbedding,

--- a/libs/langchain-community/src/vectorstores/hanavector.ts
+++ b/libs/langchain-community/src/vectorstores/hanavector.ts
@@ -625,10 +625,10 @@ export class HanaDB extends VectorStore {
   private extractKeywordSearchColumns(filter?: this["FilterType"]): string[] {
     const keywordColumns = new Set<string>();
   
-    const recurseFilters = (f?: this["FilterType"], parentKey?: string): void => {
-      if (!f || typeof f !== "object") return;
+    const recurseFilters = (filterObj?: this["FilterType"], parentKey?: string): void => {
+      if (!filterObj || typeof filterObj !== "object") return;
   
-      Object.entries(f).forEach(([key, value]) => {
+      Object.entries(filterObj).forEach(([key, value]) => {
         if (key === CONTAINS_OPERATOR) {
           if (
             parentKey &&

--- a/libs/langchain-community/src/vectorstores/hanavector.ts
+++ b/libs/langchain-community/src/vectorstores/hanavector.ts
@@ -169,7 +169,7 @@ export class HanaDB extends VectorStore {
   }
 
   /**
-   * Use this method yto chanbe the embeddings instance
+   * Use this method to change the embeddings instance.
    * 
    * Sets the embedding instance and configures the internal embedding mode 
    * if applicable.

--- a/libs/langchain-community/src/vectorstores/hanavector.ts
+++ b/libs/langchain-community/src/vectorstores/hanavector.ts
@@ -1227,7 +1227,7 @@ export class HanaDB extends VectorStore {
     if (this.useInternalEmbeddings){
       const sqlStr = `SELECT TO_NVARCHAR(VECTOR_EMBEDDING(?, 'QUERY', ?))
        AS VECTOR FROM sys.DUMMY;`
-      const queryTuple = [query, this.internalEmbeddingModelId]
+      const queryTuple = [query, this.internalEmbeddingModelId];
       const client = this.connection;
       const stm = await this.prepareQuery(client, sqlStr);
       const resultSet = await this.executeStatement(stm, queryTuple);

--- a/libs/langchain-community/src/vectorstores/hanavector.ts
+++ b/libs/langchain-community/src/vectorstores/hanavector.ts
@@ -1237,7 +1237,7 @@ export class HanaDB extends VectorStore {
           return HanaDB.parseFloatArrayFromString(row.VECTOR);
         }
       );
-      queryEmbedding = result[0]
+      queryEmbedding = result[0];
     }
     else {
       queryEmbedding = await this.embeddings.embedQuery(query);

--- a/libs/langchain-community/src/vectorstores/hanavector.ts
+++ b/libs/langchain-community/src/vectorstores/hanavector.ts
@@ -205,7 +205,7 @@ export class HanaDB extends VectorStore {
       throw new Error("Internal embedding model id is not set");
     }
     const sqlStr =
-      "SELECT TO_NVARCHAR(VECTOR_EMBEDDING('test', 'QUERY', ?)) AS TEST FROM sys.DUMMY;";
+      "SELECT COUNT(TO_NVARCHAR(VECTOR_EMBEDDING('test', 'QUERY', ?))) AS TEST FROM sys.DUMMY;";
     const client = this.connection;
     const stm = await this.prepareQuery(client, sqlStr);
     await this.executeStatement(stm, [this.internalEmbeddingModelId]);

--- a/libs/langchain-community/src/vectorstores/hanavector.ts
+++ b/libs/langchain-community/src/vectorstores/hanavector.ts
@@ -901,7 +901,7 @@ export class HanaDB extends VectorStore {
     const metadatas = documents.map((doc) => doc.metadata);
     const client = this.connection;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const sqlParams: [string, string, ...any[]][] = texts.map((text, i) => {
+    const sqlParams: [string, string, string, string, ...(string | null)[]][] = texts.map((text, i) => {
       const metadata = Array.isArray(metadatas) ? metadatas[i] : metadatas;
       const [remainingMetadata, specialMetadata] = this.splitOffSpecialMetadata(metadata);
       // Prepare the SQL parameters

--- a/libs/langchain-community/src/vectorstores/hanavector.ts
+++ b/libs/langchain-community/src/vectorstores/hanavector.ts
@@ -165,7 +165,7 @@ export class HanaDB extends VectorStore {
     this.connection = args.connection;
 
     // Set the embedding and decide whether to use internal embedding
-    this.setEmbeddings(embeddings);
+    this._setEmbeddings(embeddings);
   }
 
   /**
@@ -179,7 +179,7 @@ export class HanaDB extends VectorStore {
    *
    * @param embeddings - An instance of EmbeddingsInterface.
    */
-  public setEmbeddings(embeddings: EmbeddingsInterface): void {
+  private _setEmbeddings(embeddings: EmbeddingsInterface): void {
     this.embeddings = embeddings
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     if ((embeddings as any).isHanaInternalEmbeddings === true) {

--- a/libs/langchain-community/src/vectorstores/hanavector.ts
+++ b/libs/langchain-community/src/vectorstores/hanavector.ts
@@ -922,7 +922,6 @@ export class HanaDB extends VectorStore {
                     VALUES (?, ?, VECTOR_EMBEDDING(?, 'DOCUMENT', ?)${extraPlaceholders});`;
     const stm = await this.prepareQuery(client, sqlStr);
     await this.executeStatement(stm, sqlParams);
-    // stm.execBatch(sqlParams);
   }
 
   /**

--- a/libs/langchain-community/src/vectorstores/hanavector.ts
+++ b/libs/langchain-community/src/vectorstores/hanavector.ts
@@ -181,6 +181,7 @@ export class HanaDB extends VectorStore {
    */
   public setEmbeddings(embeddings: EmbeddingsInterface): void {
     this.embeddings = embeddings
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     if ((embeddings as any).isHanaInternalEmbeddings === true) {
       this.useInternalEmbeddings = true;
       this.internalEmbeddingModelId = (embeddings as HanaInternalEmbeddings).getModelId();

--- a/libs/langchain-community/src/vectorstores/hanavector.ts
+++ b/libs/langchain-community/src/vectorstores/hanavector.ts
@@ -515,7 +515,7 @@ export class HanaDB extends VectorStore {
               `Operator '${specialOp}' expects a non-undefined value.`
             );
           }
-        } else if (specialOp == CONTAINS_OPERATOR) {
+        } else if (specialOp === CONTAINS_OPERATOR) {
           // Special handling for keyword search
           operator = CONTAINS_OPERATOR;
           if (specialVal !== undefined) {
@@ -875,7 +875,7 @@ export class HanaDB extends VectorStore {
    * @returns A tuple where the first element is the original metadata object,
    *          and the second element is an array of special metadata values.
    */
-  private splitOffSpecialMetadata(metadata: any): [any, any[]] {
+  private splitOffSpecialMetadata(metadata: any): [any, (string | null)[]] {
     const specialMetadata: (string | null)[] = [];
     if (!metadata) {
       return [{}, []];

--- a/libs/langchain-community/src/vectorstores/tests/hanavector.fixtures.ts
+++ b/libs/langchain-community/src/vectorstores/tests/hanavector.fixtures.ts
@@ -123,6 +123,8 @@ export const TYPE_4_FILTERING_TEST_CASES: TestCase[] = [
 export const TYPE_5_FILTERING_TEST_CASES: TestCase[] = [
   { filter: { name: { $like: "a%" } }, expected: [1] },
   { filter: { name: { $like: "%a%" } }, expected: [1, 3] },
+  { filter: { name: { $contains: "bob" } }, expected: [2] },
+  { filter: { name: { $contains: "bo" } }, expected: [] },
 ];
 
 export const TYPE_6_FILTERING_TEST_CASES: TestCase[] = [


### PR DESCRIPTION
This PR introduces three key enhancements to the SAP HANA Cloud Vector Engine integration for langchainjs:

- **Dedicated Metadata Columns:**  
  Specific metadata fields are now stored in dedicated columns as well as within the JSON metadata. This behavior, modeled after the behavior in the LangChain Python implementation (see the `add_texts` method in [langchain_community/vectorstores/hanavector.py](https://github.com/langchain-ai/langchain/blob/master/libs/community/langchain_community/vectorstores/hanavector.py)), has been added to the `addVectors` method.

- **Keyword Search Filtering:**  
  The implementation now supports a `$contains` operator in filter objects. When used, it constructs a condition like:  
  ```sql
  SCORE(? IN ("<column>" EXACT SEARCH MODE 'text')) > 0
  ```  
  For columns stored only within the JSON metadata, an intermediate table is dynamically built using a `WITH` clause to project the desired JSON key into its own column. For example, filtering on a metadata field `"title"` would generate a query similar to:  
  ```sql
  WITH intermediate_result AS (
    SELECT *, JSON_VALUE(VEC_META, '$.title') AS "title"
    FROM "EMBEDDINGS"
  )
  SELECT TOP 5 "VEC_TEXT", SCORE(? IN ("title" EXACT SEARCH MODE 'text')) > 0
  FROM intermediate_result
  ORDER BY SCORE DESC;
  ```

- **Internal Embedding Functionality:**  
  By instantiating a `HanaInternalEmbeddings` object with your internal model ID, the vector store will automatically use HANA’s native `VECTOR_EMBEDDING` function to compute document and query embeddings directly in the database. This reduces external dependencies and improves performance. For instance, an internal embedding query might be constructed as:  
  ```sql
  SELECT TO_NVARCHAR(VECTOR_EMBEDDING(<query>, 'QUERY', <model_version>)) AS embedding
  FROM sys.DUMMY;
  ```  
  or  
  ```sql
  SELECT TO_NVARCHAR(VECTOR_EMBEDDING(<document>, 'DOCUMENT', <model_version>)) AS embedding
  FROM sys.DUMMY;
  ```
We modified the generated sql statement for addVectors(), similaritySearchWithScoreAndVectorByVector() and maxMarginalRelevanceSearch().

For Example, when using external embeddings, the query is built with a precomputed query vector—calculated by an external embedding instance using embedQuery() method—and then injected into the SQL. The query might include:

```sql
COSINE_SIMILARITY("VEC_VECTOR", TO_REAL_VECTOR('[1.0, 2.0, 3.0, ...]')) AS CS
```

Here, the application computes the embedding (e.g. `[1.0, 2.0, 3.0, ...]`) and passes it directly into the SQL.

In contrast, with internal embeddings the database computes the query embedding on the fly using HANA’s native `VECTOR_EMBEDDING` function. The query is constructed to call this function directly, for example:

```sql
COSINE_SIMILARITY("VEC_VECTOR", VECTOR_EMBEDDING('query text', 'QUERY', '<model_version>') AS CS
```


These features are now available in our LangChain python external integration package, and the documentation and integration tests have been updated accordingly.